### PR TITLE
feat: api 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node": "^16.18.48",
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
-        "axios": "^1.2.2",
+        "axios": "^1.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.15.0",
@@ -5198,9 +5198,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
-      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^16.18.48",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
-    "axios": "^1.2.2",
+    "axios": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.15.0",

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -1,0 +1,20 @@
+export class MemoryCache implements Cache {
+  private storage: Map<string, any> = new Map();
+
+  get<T>(key: string): T | undefined {
+    return this.storage.get(key);
+  }
+
+  set<T>(key: string, value: T): void {
+    this.storage.set(key, value);
+  }
+  has(key: string): boolean {
+    return this.storage.has(key);
+  }
+}
+
+export interface Cache {
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T): void;
+  has(key: string): boolean;
+}

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,1 +1,59 @@
-export {};
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { Cache, MemoryCache } from './cache';
+
+const BASE_URL = 'http://localhost:4000';
+
+class Http {
+  axiosInstance: AxiosInstance;
+  constructor(
+    baseURL: string,
+    private cache: Cache = new MemoryCache(),
+  ) {
+    this.axiosInstance = axios.create({ baseURL });
+  }
+
+  async request<T>(config: RequestConfig): Promise<T> {
+    const cacheKey = this.generateCacheKey(config);
+
+    if (config.method === 'GET' && this.cache.has(cacheKey)) {
+      return this.cache.get(cacheKey)!;
+    }
+
+    try {
+      const axiosConfig: AxiosRequestConfig = {
+        method: config.method,
+        url: config.url,
+        params: config.query,
+        data: config.body,
+      };
+      console.info('calling api');
+      const res: AxiosResponse<T> = await this.axiosInstance(axiosConfig);
+
+      if (config.method === 'GET') {
+        this.cache.set(cacheKey, res.data);
+      }
+
+      return res.data;
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  }
+
+  private generateCacheKey(config: RequestConfig): string {
+    return `${config.method}_${config.url}_${JSON.stringify(config.query || {})}`;
+  }
+}
+
+const http = new Http(BASE_URL);
+
+export default http;
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+type RequestConfig = {
+  method: HttpMethod;
+  url: string;
+  query?: any;
+  body?: any;
+};

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,1 +1,6 @@
-export {};
+import { Sick } from '../types';
+import http from './http';
+
+export function search(query: string): Promise<Sick[]> {
+  return http.request({ method: 'GET', url: '/sick', query: { q: query } });
+}


### PR DESCRIPTION
임시 메모리 캐싱 및  api 구현 했습니다.
사용법 : http.request({ method: 'POST', url: '/path', body: { key: 'value' } });
필요시 수정 하셔도 됩니다.